### PR TITLE
Implement full social post engagement model

### DIFF
--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -19,6 +19,7 @@ model User {
   updatedAt DateTime @updatedAt
 
   posts                  Post[]
+  postComments           PostComment[]
   meals                  MealLog[]
   weights                WeightEntry[]
   measurements           MeasurementEntry[]
@@ -164,10 +165,13 @@ model Post {
   authorId  String
   content   String
   privacy   PostPrivacy @default(FRIENDS)
+  location  String?
+  highFives Int        @default(0)
   createdAt DateTime    @default(now())
 
   author      User             @relation(fields: [authorId], references: [id])
   attachments PostAttachment[]
+  comments    PostComment[]
 
   @@index([authorId, createdAt])
 }
@@ -180,6 +184,19 @@ model PostAttachment {
   alt    String?
 
   post Post @relation(fields: [postId], references: [id])
+}
+
+model PostComment {
+  id        String   @id @default(uuid())
+  postId    String
+  authorId  String
+  content   String
+  createdAt DateTime @default(now())
+
+  post   Post @relation(fields: [postId], references: [id])
+  author User @relation(fields: [authorId], references: [id])
+
+  @@index([postId, createdAt])
 }
 
 enum PostPrivacy {

--- a/web/src/app/(tabs)/explore/page.tsx
+++ b/web/src/app/(tabs)/explore/page.tsx
@@ -3,7 +3,10 @@ import Link from "next/link";
 import { getFeed } from "@/lib/api";
 import { demoProfile } from "@/lib/demo-data";
 import {
+  Hand,
   Lock,
+  MapPin,
+  MessageCircle,
   Users,
   Search,
   Sparkles,
@@ -89,6 +92,12 @@ export default async function ExplorePage() {
                     <span className="text-xs text-foreground/60">
                       @{post.authorId}
                     </span>
+                    {post.location && (
+                      <p className="mt-1 flex items-center gap-1 text-xs text-foreground/50">
+                        <MapPin className="h-3.5 w-3.5" />
+                        <span>{post.location}</span>
+                      </p>
+                    )}
                   </div>
                 </div>
                 <PrivacyBadge privacy={post.privacy} />
@@ -107,16 +116,45 @@ export default async function ExplorePage() {
                   />
                 </div>
               )}
-              <footer className="mt-4 flex items-center justify-between text-xs text-foreground/50">
-                <span>
-                  {post.createdAt.toLocaleDateString(undefined, {
-                    month: "short",
-                    day: "numeric",
-                  })}
-                </span>
-                <button className="rounded-full bg-brand/15 px-3 py-1 font-semibold text-brand transition hover:bg-brand/25">
-                  Say congrats
-                </button>
+              <footer className="mt-4 space-y-3">
+                <div className="flex items-center justify-between text-xs text-foreground/50">
+                  <span>
+                    {post.createdAt.toLocaleDateString(undefined, {
+                      month: "short",
+                      day: "numeric",
+                    })}
+                  </span>
+                  <div className="flex items-center gap-3">
+                    <span className="flex items-center gap-1 font-semibold text-brand">
+                      <Hand className="h-3.5 w-3.5" />
+                      {post.highFives} high-fives
+                    </span>
+                    <span className="flex items-center gap-1 font-semibold text-foreground/70">
+                      <MessageCircle className="h-3.5 w-3.5" />
+                      {post.comments.length} comments
+                    </span>
+                  </div>
+                </div>
+                {post.comments.length > 0 && (
+                  <ul className="space-y-2 text-sm text-foreground/80">
+                    {post.comments.map((comment) => (
+                      <li
+                        key={comment.id}
+                        className="rounded-2xl border border-white/5 bg-surface-muted/60 px-3 py-2"
+                      >
+                        <p className="text-xs font-semibold text-foreground">
+                          {toDisplayName(comment.authorId)}
+                          <span className="ml-2 text-foreground/50">
+                            @{comment.authorId}
+                          </span>
+                        </p>
+                        <p className="mt-1 text-xs leading-relaxed text-foreground/80">
+                          {comment.content}
+                        </p>
+                      </li>
+                    ))}
+                  </ul>
+                )}
               </footer>
             </article>
           ))}

--- a/web/src/app/api/feed/route.test.ts
+++ b/web/src/app/api/feed/route.test.ts
@@ -51,6 +51,12 @@ describe("GET /api/feed", () => {
       "bob",
       "alice",
     ]);
+    expect(json.posts[0]).toEqual(
+      expect.objectContaining({
+        highFives: 0,
+        comments: [],
+      }),
+    );
   });
 
   it("validates userId", async () => {

--- a/web/src/app/api/posts/route.test.ts
+++ b/web/src/app/api/posts/route.test.ts
@@ -25,6 +25,7 @@ describe("POST /api/posts", () => {
           attachments: [
             { kind: "image", url: "https://example.com/progress.jpg" },
           ],
+          location: "  Community Gym  ",
         }),
       }),
     );
@@ -32,6 +33,9 @@ describe("POST /api/posts", () => {
     expect(response.status).toBe(201);
     const payload = await response.json();
     expect(payload.content).toBe("Goal smashed! 💪");
+    expect(payload.location).toBe("Community Gym");
+    expect(payload.highFives).toBe(0);
+    expect(payload.comments).toEqual([]);
   });
 
   it("validates post input", async () => {

--- a/web/src/lib/demo-data.ts
+++ b/web/src/lib/demo-data.ts
@@ -82,11 +82,21 @@ export const demoPosts: PostEntity[] = [
     content:
       "Crushed the interval session today! 6x400m at 4:10/km - feeling stronger every week.",
     privacy: "public",
+    location: "Riverside Track",
     attachments: [
       {
         kind: "image",
         url: "https://images.unsplash.com/photo-1571731956672-f2b94d7dd0cb",
         alt: "Running shoes on track",
+      },
+    ],
+    highFives: 18,
+    comments: [
+      {
+        id: "comment-1",
+        authorId: "demo-user",
+        content: "Splits looked so smooth—keep that cadence!",
+        createdAt: new Date(),
       },
     ],
     createdAt: new Date(),
@@ -97,7 +107,23 @@ export const demoPosts: PostEntity[] = [
     content:
       "Week 4 of the strength cycle wrapped. Adding +5kg to the deadlift next week (let's go!)",
     privacy: "close_friends",
+    location: "Forge Lab Strength",
     attachments: [],
+    highFives: 9,
+    comments: [
+      {
+        id: "comment-2",
+        authorId: "friend-1",
+        content: "Big jumps! Film the next set so we can check form.",
+        createdAt: new Date(),
+      },
+      {
+        id: "comment-3",
+        authorId: "friend-2",
+        content: "Save some PRs for the rest of us 😅",
+        createdAt: new Date(),
+      },
+    ],
     createdAt: new Date(),
   },
 ];

--- a/web/src/server/domain/social/social.service.test.ts
+++ b/web/src/server/domain/social/social.service.test.ts
@@ -27,10 +27,14 @@ describe("socialService", () => {
       content: "  First ride complete!  ",
       privacy: "friends",
       attachments: [{ kind: "image", url: "https://example.com/ride.jpg" }],
+      location: "  River Loop  ",
     });
 
     expect(post.id).toBeDefined();
     expect(post.content).toBe("First ride complete!");
+    expect(post.location).toBe("River Loop");
+    expect(post.highFives).toBe(0);
+    expect(post.comments).toEqual([]);
   });
 
   it("returns the feed including accepted friends and self", async () => {

--- a/web/src/server/testing/inMemorySocialRepositories.ts
+++ b/web/src/server/testing/inMemorySocialRepositories.ts
@@ -16,6 +16,8 @@ export class InMemoryPostRepository implements PostRepository {
       id: randomUUID(),
       createdAt: new Date(Date.now() + this.counter++),
       ...payload,
+      attachments: payload.attachments?.map((item) => ({ ...item })),
+      comments: payload.comments.map((comment) => ({ ...comment })),
     };
     this.posts.set(record.id, record);
     return record;


### PR DESCRIPTION
## Summary
- extend the social post schema and service to capture locations, high-five counts, and threaded comments
- surface the richer post data in the explore feed UI and demo content
- expand repository and API tests to cover the new engagement fields

## Testing
- npm run test *(fails: vitest: not found in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e618623f74832d908ba1b939be8074